### PR TITLE
Fix integer precision compiler warnings.

### DIFF
--- a/src/nanovg_mtl.m
+++ b/src/nanovg_mtl.m
@@ -1253,8 +1253,8 @@ static int mtlnvg__renderGetTextureSize(void* uptr, int image, int* w, int* h) {
   MNVGcontext* mtl = (MNVGcontext*)uptr;
   MNVGtexture* tex = mtlnvg__findTexture(mtl, image);
   if (tex == NULL) return 0;
-  *w = tex->tex.width;
-  *h = tex->tex.height;
+  *w = (int)tex->tex.width;
+  *h = (int)tex->tex.height;
   return 1;
 }
 


### PR DESCRIPTION
Xcode 8.3 is showing warnings for conversions from NSUInteger to int here. This is a quick fix.