### PR TITLE
fix multithreading issue on macOS

### DIFF
--- a/src/nanovg_mtl.h
+++ b/src/nanovg_mtl.h
@@ -85,10 +85,8 @@ void mnvgDeleteFramebuffer(MNVGframebuffer* framebuffer);
 // Metal bridging functions
 //
 
-// Clears the color buffer with the specified `color` for the next render pass.
-// This function simulates the combination of `glClearColor()` and `glClear()`
-// of the OpenGL backend.
-void mnvgClearWithColor(NVGcolor color);
+// Set the clear color used for every frame
+void mnvgClearColor(NVGcontext* ctx, NVGcolor color);
 
 // Returns a pointer to the corresponded `id<MTLCommandQueue>` object.
 void* mnvgCommandQueue(NVGcontext* ctx);

--- a/src/nanovg_mtl.h
+++ b/src/nanovg_mtl.h
@@ -85,8 +85,8 @@ void mnvgDeleteFramebuffer(MNVGframebuffer* framebuffer);
 // Metal bridging functions
 //
 
-// Set the clear color used for every frame
-void mnvgClearColor(NVGcontext* ctx, NVGcolor color);
+// Clear context on next frame, must be called before nvgEndFrame
+void mnvgClearWithColor(NVGcontext* ctx, NVGcolor color);
 
 // Returns a pointer to the corresponded `id<MTLCommandQueue>` object.
 void* mnvgCommandQueue(NVGcontext* ctx);

--- a/src/nanovg_mtl.m
+++ b/src/nanovg_mtl.m
@@ -199,12 +199,6 @@ typedef struct MNVGcontext MNVGcontext;
 const MTLResourceOptions kMetalBufferOptions = \
     (MTLResourceCPUCacheModeWriteCombined | MTLResourceStorageModeShared);
 
-// The color used to clear the color texture.
-MTLClearColor s_colorBufferClearColor;
-
-// The action performed at the sart of a color rendering pass.
-MTLLoadAction s_colorBufferLoadAction = MTLLoadActionClear;
-
 // Keeps the weak reference to the currently binded framebuffer.
 MNVGframebuffer* s_framebuffer = NULL;
 
@@ -1543,7 +1537,7 @@ void mnvgClearColor (NVGcontext* ctx, NVGcolor color) {
   MNVGcontext* mtl = (MNVGcontext*)nvgInternalParams(ctx)->userPtr;
   float alpha = (float)color.a;
   mtl->clearColor = MTLClearColorMake((float)color.r * alpha,
-									  (float)color.g * alpha,
+                                      (float)color.g * alpha,
                                       (float)color.b * alpha,
                                       (float)color.a);
 }

--- a/src/nanovg_mtl.m
+++ b/src/nanovg_mtl.m
@@ -1538,7 +1538,7 @@ void mnvgDeleteFramebuffer(MNVGframebuffer* framebuffer) {
   free(framebuffer);
 }
 
-void mnvgClearWithColor (NVGcontext* ctx, NVGcolor color) {
+void mnvgClearWithColor(NVGcontext* ctx, NVGcolor color) {
   MNVGcontext* mtl = (MNVGcontext*)nvgInternalParams(ctx)->userPtr;
   float alpha = (float)color.a;
   mtl->clearColor = MTLClearColorMake((float)color.r * alpha,

--- a/src/nanovg_mtl.m
+++ b/src/nanovg_mtl.m
@@ -162,6 +162,7 @@ struct MNVGcontext {
   int indexSize;
   int flags;
   vector_uint2 viewPortSize;
+  MTLClearColor clearColor;
 
   // Textures
   MNVGtexture* textures;
@@ -502,11 +503,10 @@ static id<MTLRenderCommandEncoder> mtlnvg__renderCommandEncoder(
 
   MTLRenderPassDescriptor *descriptor = \
       [MTLRenderPassDescriptor renderPassDescriptor];
-  descriptor.colorAttachments[0].clearColor = s_colorBufferClearColor;
-  descriptor.colorAttachments[0].loadAction = s_colorBufferLoadAction;
+  descriptor.colorAttachments[0].clearColor = mtl->clearColor;
+  descriptor.colorAttachments[0].loadAction = MTLLoadActionClear;
   descriptor.colorAttachments[0].storeAction = MTLStoreActionStore;
   descriptor.colorAttachments[0].texture = colorTexture;
-  s_colorBufferLoadAction = MTLLoadActionLoad;
 
   descriptor.stencilAttachment.clearStencil = 0;
   descriptor.stencilAttachment.loadAction = MTLLoadActionClear;
@@ -1539,13 +1539,13 @@ void mnvgDeleteFramebuffer(MNVGframebuffer* framebuffer) {
   free(framebuffer);
 }
 
-void mnvgClearWithColor(NVGcolor color) {
+void mnvgClearColor (NVGcontext* ctx, NVGcolor color) {
+  MNVGcontext* mtl = (MNVGcontext*)nvgInternalParams(ctx)->userPtr;
   float alpha = (float)color.a;
-  s_colorBufferClearColor = MTLClearColorMake((float)color.r * alpha,
-                                              (float)color.g * alpha,
-                                              (float)color.b * alpha,
-                                              (float)color.a);
-  s_colorBufferLoadAction = MTLLoadActionClear;
+  mtl->clearColor = MTLClearColorMake((float)color.r * alpha,
+									  (float)color.g * alpha,
+                                      (float)color.b * alpha,
+                                      (float)color.a);
 }
 
 void* mnvgCommandQueue(NVGcontext* ctx) {


### PR DESCRIPTION
fix multithreading issue by moving the clear color into the context state