### PR TITLE
add mnvgCreateImageFromHandle function

### DIFF
--- a/src/nanovg_mtl.h
+++ b/src/nanovg_mtl.h
@@ -91,7 +91,7 @@ void mnvgClearWithColor(NVGcontext* ctx, NVGcolor color);
 // Returns a pointer to the corresponded `id<MTLCommandQueue>` object.
 void* mnvgCommandQueue(NVGcontext* ctx);
 
-// Creates an image id from a `id<MTLTexture>` object pointer
+// Creates an image id from a `id<MTLTexture>` object pointer.
 int mnvgCreateImageFromHandle(NVGcontext* ctx, void* textureId, int imageFlags);
 
 // Returns a pointer to the corresponded `id<MTLDevice>` object.

--- a/src/nanovg_mtl.h
+++ b/src/nanovg_mtl.h
@@ -91,6 +91,9 @@ void mnvgClearWithColor(NVGcontext* ctx, NVGcolor color);
 // Returns a pointer to the corresponded `id<MTLCommandQueue>` object.
 void* mnvgCommandQueue(NVGcontext* ctx);
 
+// Creates an image id from a `id<MTLTexture>` object pointer
+int mnvgCreateImageFromHandle(NVGcontext* ctx, void* textureId, int imageFlags);
+
 // Returns a pointer to the corresponded `id<MTLDevice>` object.
 void* mnvgDevice(NVGcontext* ctx);
 
@@ -100,8 +103,6 @@ void* mnvgImageHandle(NVGcontext* ctx, int image);
 // Copies the pixels from the specified image into the specified `data`.
 void mnvgReadPixels(NVGcontext* ctx, int image, int x, int y, int width,
                     int height, void* data);
-
-int mnvgCreateImageFromHandle(NVGcontext* ctx, void* textureId, int imageFlags);
 
 #ifdef __cplusplus
 }

--- a/src/nanovg_mtl.h
+++ b/src/nanovg_mtl.h
@@ -101,6 +101,8 @@ void* mnvgImageHandle(NVGcontext* ctx, int image);
 void mnvgReadPixels(NVGcontext* ctx, int image, int x, int y, int width,
                     int height, void* data);
 
+int mnvgCreateImageFromHandle(NVGcontext* ctx, void* textureId, int imageFlags);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/nanovg_mtl.m
+++ b/src/nanovg_mtl.m
@@ -1558,3 +1558,16 @@ void mnvgReadPixels(NVGcontext* ctx, int image, int x, int y, int width,
          fromRegion:MTLRegionMake2D(x, y, width, height)
         mipmapLevel:0];
 }
+
+int mnvgCreateImageFromHandle(NVGcontext* ctx, void* textureId, int imageFlags) {
+  MNVGcontext* mtl = (MNVGcontext*)nvgInternalParams(ctx)->userPtr;
+  MNVGtexture* tex = mtlnvg__allocTexture(mtl);
+  
+  if (tex == NULL) return 0;
+  
+  tex->type = NVG_TEXTURE_RGBA;
+  tex->tex = (id<MTLTexture>) textureId;
+  tex->flags = imageFlags;
+  
+  return tex->id;
+}

--- a/src/nanovg_mtl.m
+++ b/src/nanovg_mtl.m
@@ -1511,6 +1511,19 @@ void* mnvgCommandQueue(NVGcontext* ctx) {
   return (__bridge void*)mtl.commandQueue;
 }
 
+int mnvgCreateImageFromHandle(NVGcontext* ctx, void* textureId, int imageFlags) {
+  MNVGcontext* mtl = (MNVGcontext*)nvgInternalParams(ctx)->userPtr;
+  MNVGtexture* tex = mtlnvg__allocTexture(mtl);
+  
+  if (tex == NULL) return 0;
+  
+  tex->type = NVG_TEXTURE_RGBA;
+  tex->tex = (id<MTLTexture>)textureId;
+  tex->flags = imageFlags;
+  
+  return tex->id;
+}
+
 void* mnvgDevice(NVGcontext* ctx) {
   MNVGcontext* mtl = (__bridge MNVGcontext*)nvgInternalParams(ctx)->userPtr;
   return (__bridge void*)mtl.metalLayer.device;
@@ -1557,17 +1570,4 @@ void mnvgReadPixels(NVGcontext* ctx, int image, int x, int y, int width,
         bytesPerRow:bytesPerRow
          fromRegion:MTLRegionMake2D(x, y, width, height)
         mipmapLevel:0];
-}
-
-int mnvgCreateImageFromHandle(NVGcontext* ctx, void* textureId, int imageFlags) {
-  MNVGcontext* mtl = (MNVGcontext*)nvgInternalParams(ctx)->userPtr;
-  MNVGtexture* tex = mtlnvg__allocTexture(mtl);
-  
-  if (tex == NULL) return 0;
-  
-  tex->type = NVG_TEXTURE_RGBA;
-  tex->tex = (id<MTLTexture>) textureId;
-  tex->flags = imageFlags;
-  
-  return tex->id;
 }


### PR DESCRIPTION
This is an implementation of CreateImageFromHandle for MTL, can be used to load textures from compressed texture formats etc, loaded with e.g. MTKTextureLoader