### PR TITLE
Use discard_fragment to fix antialiasing

### DIFF
--- a/src/nanovg_mtl_shaders.metal
+++ b/src/nanovg_mtl_shaders.metal
@@ -144,7 +144,7 @@ fragment float4 fragmentShaderAA(RasterizerData in [[stage_in]],
 
   float strokeAlpha = strokeMask(uniforms, in.ftcoord);
   if (strokeAlpha < uniforms.strokeThr) {
-    return float4(0);
+    discard_fragment();
   }
 
   if (uniforms.type == 0) {  // MNVG_SHADER_FILLGRAD


### PR DESCRIPTION
In order to indicate to Metal that we don’t want to provide a color for a fragment, we cannot simply set the returned alpha value to 0. If we did, the fragment depth would still be written into the depth buffer, causing any geometry behind the “transparent” point to be obscured.

Instead, we need to call a special function that avoids specifying a color value for the fragment entirely: discard_fragment. Calling this function prevents Metal from writing the computed depth and color values of the fragment into the renderbuffer, which allows the scene behind the fragment to show through.

Link: http://metalbyexample.com/translucency-and-transparency/