### PR TITLE
Enable integration with existing renderers

### DIFF
--- a/src/nanovg_mtl.h
+++ b/src/nanovg_mtl.h
@@ -115,6 +115,13 @@ void mnvgReadPixels(NVGcontext* ctx, int image, int x, int y, int width,
 // Returns the current OS target.
 enum MNVGTarget mnvgTarget();
 
+// Binds an MTLCommandBuffer. Intended for integration with an existing renderer.
+// The caller is responsible for invoking commit().
+void mnvgBindCommandBuffer(void* commandBuffer);
+
+// Binds an MTLTexture as the render target. Intended for integration with an existing renderer.
+void mnvgBindTargetTexture(void* texture);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR adds functions for enabling integration with existing renderers:

* `mnvgBindCommandBuffer()`
Pass an existing `MTLCommandBuffer`. Passing a command buffer disables the call to `commit()`.
* `mnvgBindTargetTexture()`
Pass an existing `MTLTexture` to render into.

These functions cover the use case where 1) the application renders its own content first,  and 2) NanoVG draws on top of the existing frame.